### PR TITLE
Update install_postfix_24.sh

### DIFF
--- a/install_postfix_24.sh
+++ b/install_postfix_24.sh
@@ -91,6 +91,9 @@ sed -i "" -E "s/(FreeBSD.*enabled:) no/\1 yes/" /usr/local/etc/pkg/repos/FreeBSD
 pkg update
 pkg install postfix libspf2 opendkim libmilter p5-perl-ldap python36 py36-postfix-policyd-spf-python postfix-postfwd opendmarc pflogsumm zip
 
+# Install script dependencies
+pkg install bash
+
 # restore repository configuration state
 #cp /root/pfSense.bkp.conf $repo2
 cp $repo_dir/*conf /usr/local/etc/pkg/repos/.


### PR DESCRIPTION
"check postwhite" requires bash at /usr/local/bin/ but there is no bash in vanilla pfsense "2.4.4-RELEASE-p1 (amd64)".